### PR TITLE
18.0 update

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,13 +1,113 @@
 turnkey-ushahidi-18.0 (1) turnkey; urgency=low
 
-  * Upgraded to latest version of Ushahidi (ushahidi/platform-release): v6.0.4
+  * Upgraded to latest version of Ushahidi (ushahidi/platform-release): v6.0.5
+    [Anton Pyrogovskyi <anton@turnkeylinux.org>]
 
-  * Updated all relevant Debian packages to Bookworm/12 versions.
+  * DEV: Dynamically determine latest Ushahidi version to install.
 
-  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
-    appliances. Here we only describe changes specific to this appliance.
+  * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
+    #1895.
+    [Jeremy Davis <jeremy@turnkeylinux.org>]
 
- -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Wed, 27 Mar 2024 18:17:02 +0100
+  * Ensure hashfile includes URL to public key - closes #1864.
+
+  * Include webmin-logviewer module by default - closes #1866.
+
+  * Upgraded base distribution to Debian 12.x/Bookworm.
+
+  * Configuration console (confconsole):
+    - Support for DNS-01 Let's Encrypt challenges.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Support for getting Let's Encrypt cert via IPv6 - closes #1785.
+    - Refactor network interface code to ensure that it works as expected and
+      supports more possible network config (e.g. hotplug interfaces & wifi).
+    - Show error message rather than stacktrace when window resized to
+      incompatable resolution - closes  #1609.
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Bugfix exception when quitting configuration of mail relay.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Improve code quality: implement typing, fstrings and make (mostly) PEP8
+      compliant.
+      [Stefan Davis <stefan@turnkeylinux.org> & Jeremy Davis
+
+  * Firstboot Initialization (inithooks):
+    - Refactor start up (now hooks into getty process, rather than having it's
+      own service).
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Refactor firstboot.d/01ipconfig (and 09hostname) to ensure that hostname
+      is included in dhcp info when set via inithooks.
+    - Package turnkey-make-ssl-cert script (from common overlay - now packaged
+      as turnkey-ssl). Refactor relevant scripts to leverage turnkey-ssl.
+    - Refactor run script - use bashisms and general tidying.
+    - Show blacklisted password characters more nicely.
+    - Misc packaging changes/improvements.
+    - Support returning output from MySQL - i.e. support 'SELECT'. (Only
+      applies to apps that include MySQL/MariaDB).
+
+  * Web management console (webmin):
+    - Upgraded webmin to v2.105.
+    - Replace webmin-shell with webmin-xterm module by default - closes #1904.
+    - Removed stunnel reverse proxy (Webmin hosted directly now).
+    - Ensure that Webmin uses HTTPS with default cert
+      (/etc/ssl/private/cert.pem).
+    - Disabled Webmin Let's Encrypt (for now).
+
+  * Web shell (shellinabox):
+    - Completely removed in v18.0 (Webmin now has a proper interactive shell).
+    - Note: previous v18.0 releases did not include webmin-xterm pkg - see
+      above webmin note &/or #1904.
+
+  * Backup (tklbam):
+    - Ported dependencies to Debian Bookworm; otherwise unchanged.
+
+  * Security hardening & improvements:
+    - Generate and use new TurnKey Bookworm keys.
+    - Automate (and require) default pinning for packages from Debian
+      backports. Also support non-free backports.
+
+  * IPv6 support:
+    - Adminer (only on LAMP based apps) listen on IPv6.
+    - Nginx/NodeJS (NodeJS based apps only) listen on IPv6.
+
+  * Misc bugfixes & feature implementations:
+    - Remove rsyslog package (systemd journal now all that's needed).
+    - Include zstd compression support.
+    - Enable new non-free-firmware apt repo by default.
+    - Improve turnkey-artisan so that it works reliably in cron jobs (only
+      Laravel based LAMP apps).
+
+  * Set mod_evasive log location - makes debugging easier.
+    [ Jeremy Davis <jeremy@turnkeylinux.org> ]
+
+  * Include and enable mod_evasive and mod_security2 by default in Apache.
+    [ Stefan Davis <Stefan@turnkeylinux.org> ]
+
+  * Includes new 'tkl-upgrade-php' helper script - to allow easy update/change
+    of PHP version - closes #1892.
+    [Marcos Méndez @ POPSOLUTIONS <https://github.com/marcos-mendez>]
+
+  * Debian default PHP updated to v8.2.
+
+  * Include new 'tkl-update-php' script - to make updating/changing PHP
+    version easier for end users.
+    [Marcos Méndez @ POPSOLUTIONS <https://github.com/marcos-mendez>]
+
+  * DEV: Add support for setting max_execution_time & max_input_vars in
+    php.ini via appliance Makefile (PHP_MAX_EXECUTION_TIME &
+    PHP_MAX_INPUT_VARS).
+
+  * Use MariaDB (MySQL replacement) v10.11.3 (from debian repos).
+
+  * Install composer from Debian repos (previously installed from source)
+    [ Stefan Davis <Stefan@turnkeylinux.org> ]
+
+  * Improvments to 'turnkey-artisan' wrapper/helper script.
+    [ Stefan Davis <stefan@turnkeylinux.org> ]
+
+  * Install composer from Debian repos (previously installed from source)
+    [ Stefan Davis <Stefan@turnkeylinux.org> ]
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 03 Apr 2024 22:01:02 +0000
 
 turnkey-ushahidi-17.1 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-ushahidi-18.0 (1) turnkey; urgency=low
+
+  * Upgraded to latest version of Ushahidi (ushahidi/platform-release): v6.0.4
+
+  * Updated all relevant Debian packages to Bookworm/12 versions.
+
+  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Wed, 27 Mar 2024 18:17:02 +0100
+
 turnkey-ushahidi-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -6,9 +6,10 @@ dl() {
 }
 
 SRC=/usr/local/src
-VERSION="v6.0.4"
+REPO="ushahidi/platform-release"
+VERSION=$(gh_releases "$REPO" | sort -V | grep -v 'rc' | tail -1)
 FILE="ushahidi-platform-release-$VERSION.tar.gz"
-URL="https://github.com/ushahidi/platform-release/releases/download/$VERSION/$FILE"
+URL="https://github.com/$REPO/releases/download/$VERSION/$FILE"
 
 dl $URL $SRC
 mv $SRC/$FILE $SRC/ushahidi.tar.gz

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -6,7 +6,7 @@ dl() {
 }
 
 SRC=/usr/local/src
-VERSION="v5.3.1"
+VERSION="v6.0.4"
 FILE="ushahidi-platform-release-$VERSION.tar.gz"
 URL="https://github.com/ushahidi/platform-release/releases/download/$VERSION/$FILE"
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -53,7 +53,7 @@ mkdir -p $WEBROOT/platform/storage/{logs,app,framework,passport}
 chown -R www-data:www-data $WEBROOT
 chmod +x $WEBROOT/platform/bin/phinx
 
-runuser -l www-data -s /bin/bash -c "cd $WEBROOT/platform && php artisan phinx:migrate"
+turnkey-artisan phinx:migrate
 turnkey-artisan passport:keys
 
 # update admin user email & set site name

--- a/conf.d/main
+++ b/conf.d/main
@@ -52,7 +52,8 @@ sed -i "\|^export WEBROOT| s|=.*|=$WEBROOT/platform|" /usr/local/bin/turnkey-art
 mkdir -p $WEBROOT/platform/storage/{logs,app,framework,passport}
 chown -R www-data:www-data $WEBROOT
 chmod +x $WEBROOT/platform/bin/phinx
-runuser -l www-data -s /bin/bash -c "cd $WEBROOT/platform && ./bin/phinx migrate -c phinx.php"
+
+runuser -l www-data -s /bin/bash -c "cd $WEBROOT/platform && php artisan phinx:migrate"
 turnkey-artisan passport:keys
 
 # update admin user email & set site name


### PR DESCRIPTION
Includes Anton's changes https://github.com/turnkeylinux-apps/ushahidi/pull/16. Plus a few other tweaks:
- common changes in changelog
- dynamically determine latest version
- use `turnkey-artisan` (rather than `runuser ...`)